### PR TITLE
{cmake} Clarify finding of Qt

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,8 +70,6 @@ jobs:
         run: >
           mkdir cccorelib-build
 
-          echo ${Qt5_DIR}
-
           cmake
           -B cccorelib-build
           -G "${{ matrix.config.generator }}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,11 +13,26 @@ project( CCCoreLib
 )
 
 # Options
-option( CC-CORE-LIB_USE_CGAL "Compile CCCoreLib with CGAL (to enable Delaunay 2.5D triangulation with a GPL compliant licence)" OFF )
-option( CC-CORE-LIB_USE_TBB "Compile CCCoreLib with Intel Threading Building Blocks lib (enables some parallel processing )" OFF )
-option( CC-CORE-LIB_USE_QT "Compile CCCoreLib with Qt (to enable parallel processing)" ON )
-option( CC-CORE-LIB_SHARED "Compile CCCoreLib as a shared library" ON )
-option( CC-CORE-LIB_SCALAR_DOUBLE "Define ScalarType as double (instead of float)" OFF )
+option( CC-CORE-LIB_USE_CGAL
+    "Compile CCCoreLib with CGAL (to enable Delaunay 2.5D triangulation with a GPL compliant licence)"
+    OFF
+)
+option( CC-CORE-LIB_USE_TBB
+    "Compile CCCoreLib with Intel Threading Building Blocks lib (enables some parallel processing )"
+    OFF
+)
+option( CC-CORE-LIB_USE_QT
+    "Compile CCCoreLib with Qt (to enable parallel processing)"
+    ON
+)
+option( CC-CORE-LIB_SHARED
+    "Compile CCCoreLib as a shared library"
+    ON
+)
+option( CC-CORE-LIB_SCALAR_DOUBLE
+    "Define ScalarType as double (instead of float)"
+    OFF
+)
 
 # Add the library (shared or static)
 if ( CC-CORE-LIB_SHARED )
@@ -117,7 +132,10 @@ endif()
 # Windows-specific flags
 if ( WIN32 )
 	# VLD for mem leak checking
-	option( CC-CORE-LIB_USE_VISUAL_LEAK_DETECTOR "Check to activate compilation (in debug) with Visual Leak Detector" OFF )
+	option( CC-CORE-LIB_USE_VISUAL_LEAK_DETECTOR
+        "Check to activate compilation (in debug) with Visual Leak Detector"
+        OFF
+    )
 
 	if ( CC-CORE-LIB_USE_VISUAL_LEAK_DETECTOR )
 		target_compile_definitions( CCCoreLib
@@ -126,7 +144,8 @@ if ( WIN32 )
 		)
 	endif()
 
-	# Disable SECURE_SCL (see http://channel9.msdn.com/shows/Going+Deep/STL-Iterator-Debugging-and-Secure-SCL/)
+	# Disable SECURE_SCL
+    # See https://channel9.msdn.com/shows/Going+Deep/STL-Iterator-Debugging-and-Secure-SCL/
 	target_compile_definitions( CCCoreLib
 		PRIVATE
 			"$<$<CONFIG:RELEASE>:_SECURE_SCL=0>"
@@ -190,18 +209,6 @@ endif()
 
 # QT (optional)
 if ( CC-CORE-LIB_USE_QT )
-	if ( !QT5_ROOT_PATH )
-		set( QT5_ROOT_PATH CACHE PATH "Qt5 root directory (i.e. where the 'bin' folder lies)" )
-	endif()
-
-	if ( QT5_ROOT_PATH )
-		list( APPEND CMAKE_PREFIX_PATH ${QT5_ROOT_PATH} )
-	endif()
-
-	set( CMAKE_AUTOMOC ON )
-	set( CMAKE_AUTORCC ON )
-	set( CMAKE_AUTOUIC ON )
-
 	find_package( Qt5
 		COMPONENTS
 			Concurrent
@@ -209,6 +216,10 @@ if ( CC-CORE-LIB_USE_QT )
 			Widgets
 		REQUIRED
 	)
+
+	set( CMAKE_AUTOMOC ON )
+	set( CMAKE_AUTORCC ON )
+	set( CMAKE_AUTOUIC ON )
 
 	target_link_libraries( CCCoreLib
 		PUBLIC
@@ -225,7 +236,7 @@ if ( CC-CORE-LIB_USE_QT )
 endif()
 
 # Install
-# Details here: https://cliutils.gitlab.io/modern-cmake/chapters/install/installing.html
+# See: https://cliutils.gitlab.io/modern-cmake/chapters/install/installing.html
 install(
 	TARGETS
 		CCCoreLib

--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ It uses CMake, requires C++14, and compiles & runs on Linux, macOS, and Windows.
 | CC-CORE-LIB_SHARED | Compile as a shared library | ON |
 | CC-CORE-LIB_SCALAR_DOUBLE | Define _ScalarType_ as double (instead of float) | OFF |
 
+### Qt Option (Qt5_DIR)
+
+If `CC-CORE-LIB_USE_QT` is on (it is by default), then you may need to set `Qt5_DIR` to point to your Qt inatallation directory. This is the directory containing the `bin`, `doc`, `include`, `lib`, [etc.] directories.
+
+From this, cmake will determine `Qt5Concurrent_DIR`, `Qt5Core_DIR`, and `Qt5Widgets_DIR`, so there's no need to set those explicitly.
+
 ## Things We Have Yet To Do
 
 - contribution guidelines (including coding style)


### PR DESCRIPTION
Qt5_DIR is the built-in way to find Qt's cmake files, so we can avoid the extra non-standard code

Also fixes some formatting & removes debug "echo" from actions file

Fixes #3