### PR TITLE
{cmake} Set CMAKE_BUILD_PARALLEL_LEVEL on Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,18 +11,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scalar_double: ["OFF", "ON"]
+        # scalar_double: ["OFF", "ON"]
+        scalar_double: ["OFF"]
         config:
-          - {
-              name: "macOS Clang",
-              os: macos-latest,
-              generator: "Ninja",
-            }
-          - {
-              name: "Ubuntu GCC",
-              os: ubuntu-latest,
-              generator: "Ninja",
-            }
+          # - {
+          #     name: "macOS Clang",
+          #     os: macos-latest,
+          #     generator: "Ninja",
+          #   }
+          # - {
+          #     name: "Ubuntu GCC",
+          #     os: ubuntu-latest,
+          #     generator: "Ninja",
+          #   }
           - {
               name: "Windows MSVC",
               os: windows-latest,
@@ -71,8 +72,6 @@ jobs:
           # Docs tell us that the VM has 2 cores, so mimic ninja with its +2
           echo "::set-env name=CMAKE_BUILD_PARALLEL_LEVEL::4"
 
-          env
-
       - name: Configure MSVC console (Windows)
         if:  matrix.config.os == 'windows-latest'
         uses: ilammy/msvc-dev-cmd@v1
@@ -81,9 +80,7 @@ jobs:
         run: >
           mkdir cccorelib-build
 
-          echo "Number of cores: ${CMAKE_BUILD_PARALLEL_LEVEL}"
-
-          env
+          echo "Number of cores: ${{ env.CMAKE_BUILD_PARALLEL_LEVEL }}"
 
           cmake
           -B cccorelib-build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,4 +92,6 @@ jobs:
           .
 
       - name: Build
-        run: cmake --build cccorelib-build --parallel --config Release
+        run: |
+          env | sort
+          cmake --build cccorelib-build --parallel --config Release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,6 @@ jobs:
 
       - name: Set number of cores (Windows)
         if:  matrix.config.os == 'windows-latest'
-        shell: sh -l {0}
         run: |
           # Docs tell us that the VM has 2 cores, so mimic ninja with its +2
           echo "::set-env name=CMAKE_BUILD_PARALLEL_LEVEL::4"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,19 +11,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # scalar_double: ["OFF", "ON"]
-        scalar_double: ["OFF"]
+        scalar_double: ["OFF", "ON"]
         config:
-          # - {
-          #     name: "macOS Clang",
-          #     os: macos-latest,
-          #     generator: "Ninja",
-          #   }
-          # - {
-          #     name: "Ubuntu GCC",
-          #     os: ubuntu-latest,
-          #     generator: "Ninja",
-          #   }
+          - {
+              name: "macOS Clang",
+              os: macos-latest,
+              generator: "Ninja",
+            }
+          - {
+              name: "Ubuntu GCC",
+              os: ubuntu-latest,
+              generator: "Ninja",
+            }
           - {
               name: "Windows MSVC",
               os: windows-latest,
@@ -79,8 +78,6 @@ jobs:
         run: >
           mkdir cccorelib-build
 
-          echo "Number of cores: ${{ env.CMAKE_BUILD_PARALLEL_LEVEL }}"
-
           cmake
           -B cccorelib-build
           -G "${{ matrix.config.generator }}"
@@ -92,5 +89,4 @@ jobs:
 
       - name: Build
         run: |
-          env | sort
           cmake --build cccorelib-build --parallel --config Release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,6 +66,7 @@ jobs:
 
       - name: Set number of cores (Windows)
         if:  matrix.config.os == 'windows-latest'
+        shell: sh -l {0}
         run: |
           # Docs tell us that the VM has 2 cores, so mimic ninja with its +2
           echo "::set-env name=CMAKE_BUILD_PARALLEL_LEVEL::4"
@@ -77,7 +78,7 @@ jobs:
       - name: Configure
         run: >
           mkdir cccorelib-build
-          
+
           echo "Number of cores: ${CMAKE_BUILD_PARALLEL_LEVEL}"
 
           cmake

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,6 +64,12 @@ jobs:
           channels: conda-forge
           miniconda-version: 'latest'
 
+      - name: Set number of cores (Windows)
+        if:  matrix.config.os == 'windows-latest'
+        run: |
+          # Docs tell us that the VM has 2 cores, so mimic ninja with its +2
+          echo "::set-env name=CMAKE_BUILD_PARALLEL_LEVEL::4"
+
       - name: Configure MSVC console (Windows)
         if:  matrix.config.os == 'windows-latest'
         uses: ilammy/msvc-dev-cmd@v1
@@ -71,6 +77,8 @@ jobs:
       - name: Configure
         run: >
           mkdir cccorelib-build
+          
+          echo "Number of cores: ${CMAKE_BUILD_PARALLEL_LEVEL}"
 
           cmake
           -B cccorelib-build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,6 +71,8 @@ jobs:
           # Docs tell us that the VM has 2 cores, so mimic ninja with its +2
           echo "::set-env name=CMAKE_BUILD_PARALLEL_LEVEL::4"
 
+          env
+
       - name: Configure MSVC console (Windows)
         if:  matrix.config.os == 'windows-latest'
         uses: ilammy/msvc-dev-cmd@v1
@@ -80,6 +82,8 @@ jobs:
           mkdir cccorelib-build
 
           echo "Number of cores: ${CMAKE_BUILD_PARALLEL_LEVEL}"
+
+          env
 
           cmake
           -B cccorelib-build


### PR DESCRIPTION
Setting "--parallel" on cmake uses CMAKE_BUILD_PARALLEL_LEVEL to determine number of jobs.

Could get fancy to determine number of cores but it's complicated with setting env vars between shells, so go for simplicity.