### PR TITLE
Cleanup some function signatures

### DIFF
--- a/include/Delaunay2dMesh.h
+++ b/include/Delaunay2dMesh.h
@@ -8,6 +8,7 @@
 #include "SimpleTriangle.h"
 
 #include <cstddef>
+#include <string>
 #include <vector>
 
 namespace CCCoreLib

--- a/include/Delaunay2dMesh.h
+++ b/include/Delaunay2dMesh.h
@@ -20,6 +20,7 @@ namespace CCCoreLib
 	class CC_CORE_LIB_API Delaunay2dMesh : public GenericIndexedMesh
 	{
 	public:
+		static constexpr int USE_ALL_POINTS = 0;
 
 		//! Delaunay2dMesh constructor
 		Delaunay2dMesh();
@@ -45,23 +46,23 @@ namespace CCCoreLib
 
 		//! Build the Delaunay mesh on top a set of 2D points
 		/** \param points2D a set of 2D points
-			\param pointCountToUse number of points to use from the input set (0 = all)
-			\param outputErrorStr error string as output by the CGAL lib. (if any) [optional]
+			\param pointCountToUse number of points to use from the input set (USE_ALL_POINTS = all)
+			\param outputErrorStr error string as output by the CGAL lib. (if any)
 			\return success
 		**/
 		virtual bool buildMesh(	const std::vector<CCVector2>& points2D,
-								std::size_t pointCountToUse = 0,
-								char* outputErrorStr = nullptr);
+								std::size_t pointCountToUse,
+								std::string& outputErrorStr );
 
 		//! Build the Delaunay mesh from a set of 2D polylines
 		/** \param points2D a set of 2D points
 			\param segments2D constraining segments (as 2 indexes per segment)
-			\param outputErrorStr error string as output by the CGAL lib. (if any) [optional]
+			\param outputErrorStr error string as output by the CGAL lib. (if any)
 			\return success
 		**/
 		virtual bool buildMesh(	const std::vector<CCVector2>& points2D,
 								const std::vector<int>& segments2D,
-								char* outputErrorStr = nullptr);
+								std::string& outputErrorStr );
 
 		//! Removes the triangles falling outside of a given (2D) polygon
 		/** \param vertices2D vertices of the mesh as 2D points (typically the one used to triangulate the mesh!)

--- a/include/Neighbourhood.h
+++ b/include/Neighbourhood.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <string>
+
 //Local
 #include "CCMiscTools.h"
 #include "GenericIndexedCloudPersist.h"
@@ -21,7 +23,11 @@ namespace CCCoreLib
 	class CC_CORE_LIB_API Neighbourhood
 	{
 	public:
-
+		static constexpr int IGNORE_MAX_EDGE_LENGTH = 0;
+		
+		static constexpr bool DUPLICATE_VERTICES = true;
+		static constexpr bool DO_NOT_DUPLICATE_VERTICES = false;
+		
 		//! Geometric properties/elements that can be computed from the set of points (see Neighbourhood::getGeometricalElement)
 		enum GeomElement {		FLAG_DEPRECATED			= 0,
 								FLAG_GRAVITY_CENTER		= 1,
@@ -50,12 +56,12 @@ namespace CCCoreLib
 		//! Applies 2D Delaunay triangulation
 		/** Cloud selection is first projected on the best least-square plane.
 			\param duplicateVertices whether to duplicate vertices (a new point cloud is created) or to use the associated one)
-			\param maxEdgeLength max edge length for output triangles (0 = ignored)
-			\param errorStr error (if any) [optional]
+			\param maxEdgeLength max edge length for output triangles (IGNORE_MAX_EDGE_LENGTH = ignored)
+			\param outputErrorStr error (if any)
 		***/
-		GenericIndexedMesh* triangulateOnPlane(	bool duplicateVertices = false,
-												PointCoordinateType maxEdgeLength = 0,
-												char* errorStr = nullptr);
+		GenericIndexedMesh* triangulateOnPlane( bool duplicateVertices,
+												PointCoordinateType maxEdgeLength,
+												std::string& outputErrorStr );
 
 		//! Fit a quadric on point set (see getQuadric) then triangulates it inside bounding box
 		GenericIndexedMesh* triangulateFromQuadric(unsigned stepsX, unsigned stepsY);

--- a/include/PointProjectionTools.h
+++ b/include/PointProjectionTools.h
@@ -11,21 +11,24 @@
 
 //System
 #include <list>
-
-//! Triangulation types
-enum CC_TRIANGULATION_TYPES {	DELAUNAY_2D_AXIS_ALIGNED  = 1,		/**< Delaunay 2D triangulation in an axis-aligned plane **/
-								DELAUNAY_2D_BEST_LS_PLANE = 2,		/**< Delaunay 2D with points projected on the best least square fitting plane **/
-							};
+#include <string>
 
 namespace CCCoreLib
 {
 	class GenericIndexedMesh;
 	class GenericProgressCallback;
-
+	
+	//! Triangulation types
+	enum TRIANGULATION_TYPES {
+		DELAUNAY_2D_AXIS_ALIGNED  = 1,		/**< Delaunay 2D triangulation in an axis-aligned plane **/
+		DELAUNAY_2D_BEST_LS_PLANE = 2,		/**< Delaunay 2D with points projected on the best least square fitting plane **/
+	};
+	
 	//! Several point cloud re-projection algorithms ("developpee", translation, rotation, etc.)
 	class CC_CORE_LIB_API PointProjectionTools : public CCToolbox
 	{
 	public:
+		static constexpr int IGNORE_MAX_EDGE_LENGTH = 0;
 
 		//! A scaled geometrical transformation (scale + rotation + translation)
 		/** P' = s.R.P + T
@@ -111,16 +114,16 @@ namespace CCCoreLib
 			may present however several topological aberrations ;).
 			\param cloud a point cloud
 			\param type the triangulation strategy
-			\param maxEdgeLength max edge length for output triangles (0 = ignored)
+			\param maxEdgeLength max edge length for output triangles (IGNORE_MAX_EDGE_LENGTH = ignored)
 			\param dim projection dimension (for axis-aligned meshes)
-			\param errorStr error (if any) [optional]
+			\param outputErrorStr error (if any)
 			\return a mesh
 		**/
 		static GenericIndexedMesh* computeTriangulation(GenericIndexedCloudPersist* cloud,
-														CC_TRIANGULATION_TYPES type = DELAUNAY_2D_AXIS_ALIGNED,
-														PointCoordinateType maxEdgeLength = 0,
-														unsigned char dim = 2,
-														char* errorStr = nullptr);
+														TRIANGULATION_TYPES type,
+														PointCoordinateType maxEdgeLength,
+														unsigned char dim,
+														std::string& outputErrorStr);
 
 		//! Indexed 2D vector
 		/** Used for convex and concave hull computation

--- a/src/Delaunay2dMesh.cpp
+++ b/src/Delaunay2dMesh.cpp
@@ -59,10 +59,9 @@ void Delaunay2dMesh::linkMeshWith(GenericIndexedCloud* aCloud, bool passOwnershi
 
 bool Delaunay2dMesh::buildMesh(	const std::vector<CCVector2>& points2D,
 								const std::vector<int>& segments2D,
-								char* outputErrorStr/*=0*/)
+								std::string &outputErrorStr )
 {
 #if defined(CC_CORE_LIB_USES_CGAL_LIB)
-
 	//CGAL boilerplate
 	using K = CGAL::Exact_predicates_inexact_constructions_kernel;
 	//We define a vertex_base with info. The "info" (std::size_t) allow us to keep track of the original point index.
@@ -81,8 +80,7 @@ bool Delaunay2dMesh::buildMesh(	const std::vector<CCVector2>& points2D,
 		constraints.reserve(constrCount);
 	} catch (const std::bad_alloc&)
 	{
-		if (outputErrorStr)
-			strcpy(outputErrorStr, "Not enough memory");
+		outputErrorStr = "Not enough memory";
 		return false;
 	};
 
@@ -115,22 +113,17 @@ bool Delaunay2dMesh::buildMesh(	const std::vector<CCVector2>& points2D,
 	m_globalIterator = m_triIndexes;
 	m_globalIteratorEnd = m_triIndexes + 3*m_numberOfTriangles;
 	return true;
-
 #else
-
-	if (outputErrorStr)
-		strcpy(outputErrorStr, "CGAL library not supported");
+	outputErrorStr = "CGAL library not supported";
 	return false;
-
 #endif
 }
 
 bool Delaunay2dMesh::buildMesh(	const std::vector<CCVector2>& points2D,
-								std::size_t pointCountToUse/*=0*/,
-								char* outputErrorStr/*=0*/)
+								std::size_t pointCountToUse,
+								std::string& outputErrorStr )
 {
 #if defined(CC_CORE_LIB_USES_CGAL_LIB)
-
 	//CGAL boilerplate
 	using K = CGAL::Exact_predicates_inexact_constructions_kernel;
 	//We define a vertex_base with info. The "info" (std::size_t) allow us to keep track of the original point index.
@@ -150,8 +143,7 @@ bool Delaunay2dMesh::buildMesh(	const std::vector<CCVector2>& points2D,
 
 	if (pointCount < 3)
 	{
-		if (outputErrorStr)
-			strcpy(outputErrorStr, "Not enough points");
+		outputErrorStr = "Not enough points";
 		return false;
 	}
 
@@ -161,8 +153,7 @@ bool Delaunay2dMesh::buildMesh(	const std::vector<CCVector2>& points2D,
 	}
 	catch (const std::bad_alloc&)
 	{
-		if (outputErrorStr)
-			strcpy(outputErrorStr, "Not enough memory");
+		outputErrorStr = "Not enough memory";
 		return false;
 	};
 
@@ -200,13 +191,9 @@ bool Delaunay2dMesh::buildMesh(	const std::vector<CCVector2>& points2D,
 	m_globalIterator = m_triIndexes;
 	m_globalIteratorEnd = m_triIndexes + 3*m_numberOfTriangles;
 	return true;
-
 #else
-
-	if (outputErrorStr)
-		strcpy(outputErrorStr, "CGAL library not supported");
+	outputErrorStr = "CGAL library not supported";
 	return false;
-
 #endif
 }
 
@@ -416,8 +403,8 @@ Delaunay2dMesh* Delaunay2dMesh::TesselateContour(const std::vector<CCVector2>& c
 	if (contourPoints.back().x == contourPoints.front().x &&  contourPoints.back().y == contourPoints.front().y)
 		--count;
 
-	char errorStr[1024];
-	Delaunay2dMesh* mesh = new Delaunay2dMesh();
+	std::string errorStr;
+	Delaunay2dMesh* mesh = new Delaunay2dMesh;
 	if (!mesh->buildMesh(contourPoints, count, errorStr) || mesh->size() == 0)
 	{
 		//triangulation failed

--- a/src/LocalModel.cpp
+++ b/src/LocalModel.cpp
@@ -188,7 +188,11 @@ LocalModel* LocalModel::New(LOCAL_MODEL_TYPES type,
 
 		case TRI:
 		{
-			GenericMesh* tri = subset.triangulateOnPlane(true); //'subset' is potentially associated to a volatile ReferenceCloud, so we must duplicate vertices!
+			std::string	errorStr;
+			
+			GenericMesh* tri = subset.triangulateOnPlane( Neighbourhood::DUPLICATE_VERTICES,
+														  Neighbourhood::IGNORE_MAX_EDGE_LENGTH,
+														  errorStr ); //'subset' is potentially associated to a volatile ReferenceCloud, so we must duplicate vertices!
 			if (tri)
 			{
 				return new DelaunayLocalModel(tri, center, squaredRadius);

--- a/src/Neighbourhood.cpp
+++ b/src/Neighbourhood.cpp
@@ -664,15 +664,14 @@ bool Neighbourhood::compute3DQuadric(double quadricEquation[10])
 	return true;
 }
 
-GenericIndexedMesh* Neighbourhood::triangulateOnPlane(	bool duplicateVertices/*=false*/,
-														PointCoordinateType maxEdgeLength/*=0*/,
-														char* errorStr/*=0*/)
+GenericIndexedMesh* Neighbourhood::triangulateOnPlane( bool duplicateVertices,
+													   PointCoordinateType maxEdgeLength,
+													   std::string& outputErrorStr )
 {
 	if (m_associatedCloud->size() < CC_LOCAL_MODEL_MIN_SIZE[TRI])
 	{
 		//can't compute LSF plane with less than 3 points!
-		if (errorStr)
-			strcpy(errorStr,"Not enough points");
+		outputErrorStr = "Not enough points";
 		return nullptr;
 	}
 
@@ -691,7 +690,7 @@ GenericIndexedMesh* Neighbourhood::triangulateOnPlane(	bool duplicateVertices/*=
 		Delaunay2dMesh* dm = new Delaunay2dMesh();
 
 		//triangulate the projected points
-		if (!dm->buildMesh(points2D,0,errorStr))
+		if (!dm->buildMesh(points2D, Delaunay2dMesh::USE_ALL_POINTS, outputErrorStr))
 		{
 			delete dm;
 			return nullptr;
@@ -704,8 +703,7 @@ GenericIndexedMesh* Neighbourhood::triangulateOnPlane(	bool duplicateVertices/*=
 			const unsigned count = m_associatedCloud->size();
 			if (!cloud->reserve(count))
 			{
-				if (errorStr)
-					strcpy(errorStr,"Not enough memory");
+				outputErrorStr = "Not enough memory";
 				delete dm;
 				delete cloud;
 				return nullptr;
@@ -726,8 +724,7 @@ GenericIndexedMesh* Neighbourhood::triangulateOnPlane(	bool duplicateVertices/*=
 			if (dm->size() == 0)
 			{
 				//no more triangles?
-				if (errorStr)
-					strcpy(errorStr,"Not triangle left after pruning");
+				outputErrorStr = "Not triangle left after pruning";
 				delete dm;
 				dm = nullptr;
 			}


### PR DESCRIPTION
- use std::string instead of char * (fixes #27)
- move enum into namespace
- remove default arguments
- give names to some arguments (DUPLICATE_VERTICES, DO_NOT_DUPLICATE_VERTICES instead of true/false) so it's easier to read when used