### PR TITLE
{cmake} Fixes TBB linking on Ubuntu 19.x

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,7 +162,7 @@ endif()
 # TBB (optional)
 # Must come before CGAL so it can use TBB properly
 if ( CCCORELIB_USE_TBB )
-	find_package( TBB COMPONENTS tbb )
+	find_package( TBB COMPONENTS tbb CONFIG )
 
 	if ( TBB_FOUND )
 		target_link_libraries( CCCoreLib


### PR DESCRIPTION
Ubuntu 19.x includes files for both CONFIG (TBBMakeConfig.cmake) and MODULE (FindTBB.cmake) style find_package. We need to force CONFIG because that is the style we are expecting.

Related #2
Fixes #33