### PR TITLE
Making the GenericCloud::enableScalarField method smarter

### DIFF
--- a/include/GenericCloud.h
+++ b/include/GenericCloud.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-2.0-or-later
-// Copyright Â© EDF R&D / TELECOM ParisTech (ENST-TSI)
+// Copyright © EDF R&D / TELECOM ParisTech (ENST-TSI)
 
 #pragma once
 
@@ -80,6 +80,8 @@ namespace CCCoreLib
 			this method gives the signal for its creation. Otherwise, if possible
 			the structure size should be pre-reserved with the same number of
 			elements as the point cloud.
+			\warning If the cloud is empty, the scalar field will be empty as well.
+			         The scalar field will be reserved with the same capacity as the cloud.
 		**/
 		virtual bool enableScalarField() = 0;
 

--- a/include/PointCloudTpl.h
+++ b/include/PointCloudTpl.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-2.0-or-later
-// Copyright Â© EDF R&D / TELECOM ParisTech (ENST-TSI)
+// Copyright © EDF R&D / TELECOM ParisTech (ENST-TSI)
 
 #pragma once
 
@@ -83,6 +83,12 @@ namespace CCCoreLib
 
 		bool enableScalarField() override
 		{
+			if (m_points.empty() && m_points.capacity() == 0)
+			{
+				//on must call resize or reserve on the cloud first
+				return false;
+			}
+
 			ScalarField* currentInScalarField = getCurrentInScalarField();
 
 			if (!currentInScalarField)
@@ -113,7 +119,16 @@ namespace CCCoreLib
 				m_currentOutScalarFieldIndex = m_currentInScalarFieldIndex;
 			}
 
-			return currentInScalarField->resizeSafe(m_points.size());
+			if (m_points.empty())
+			{
+				//if the cloud is empty, with a reserved capacity, we do the same on the SF
+				return currentInScalarField->reserveSafe(m_points.capacity());
+			}
+			else
+			{
+				//otherwise we resize the SF with the current number of points so that they match
+				return currentInScalarField->resizeSafe(m_points.size());
+			}
 		}
 
 		bool isScalarFieldEnabled() const override
@@ -247,8 +262,8 @@ namespace CCCoreLib
 		{
 			//NaN coordinates check
 			if (	P.x != P.x
-					||	P.y != P.y
-					||	P.z != P.z)
+				||	P.y != P.y
+				||	P.z != P.z)
 			{
 				//replace NaN point by (0, 0, 0)
 				CCVector3 fakeP(0, 0, 0);
@@ -460,9 +475,9 @@ namespace CCCoreLib
 		//! Swaps two points (and their associated scalar values!)
 		virtual void swapPoints(unsigned firstIndex, unsigned secondIndex)
 		{
-			if (firstIndex == secondIndex
-					|| firstIndex >= m_points.size()
-					|| secondIndex >= m_points.size())
+			if (	firstIndex == secondIndex
+				||	firstIndex >= m_points.size()
+				||	secondIndex >= m_points.size())
 			{
 				return;
 			}

--- a/src/AutoSegmentationTools.cpp
+++ b/src/AutoSegmentationTools.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-2.0-or-later
-// Copyright Â© EDF R&D / TELECOM ParisTech (ENST-TSI)
+// Copyright © EDF R&D / TELECOM ParisTech (ENST-TSI)
 
 #include <AutoSegmentationTools.h>
 
@@ -39,7 +39,11 @@ int AutoSegmentationTools::labelConnectedComponents(GenericIndexedCloudPersist* 
 	}
 
 	//we use the default scalar field to store components labels
-	theCloud->enableScalarField();
+	if (!theCloud->enableScalarField())
+	{
+		//failed to enable a scalar field
+		return -1;
+	}
 
 	int result = theOctree->extractCCs(level, sixConnexity, progressCb);
 

--- a/src/StatisticalTestingTools.cpp
+++ b/src/StatisticalTestingTools.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-2.0-or-later
-// Copyright Â© EDF R&D / TELECOM ParisTech (ENST-TSI)
+// Copyright © EDF R&D / TELECOM ParisTech (ENST-TSI)
 
 #include <StatisticalTestingTools.h>
 
@@ -303,17 +303,27 @@ double StatisticalTestingTools::testCloudWithStatisticalModel(const GenericDistr
 		}
 	}
 
-	//on active le champ scalaire (IN) pour recevoir les distances du Chi2
-	theCloud->enableScalarField();
+	//we activate the 'IN' scalar field to store the Chi2 distances
+	if (!theCloud->enableScalarField())
+	{
+		if (!inputOctree)
+			delete theOctree;
+		return -3.0;
+	}
 
 	unsigned char level = theOctree->findBestLevelForAGivenPopulationPerCell(numberOfNeighbours);
 
 	unsigned numberOfChi2Classes = static_cast<unsigned>(ceil(sqrt(static_cast<double>(numberOfNeighbours))));
 
 	//Chi2 hisogram values
-	unsigned* histoValues = new unsigned[numberOfChi2Classes];
-	if (!histoValues)
+	std::vector<unsigned> histoValues;
+	try
 	{
+		histoValues.resize(numberOfChi2Classes);
+	}
+	catch (const std::bad_alloc&)
+	{
+		//not enough memory
 		if (!inputOctree)
 			delete theOctree;
 		return -3.0;
@@ -323,7 +333,7 @@ double StatisticalTestingTools::testCloudWithStatisticalModel(const GenericDistr
 	ScalarType customHistoMin = 0;
 	ScalarType* histoMax = nullptr;
 	ScalarType customHistoMax = 0;
-	if (strcmp(distrib->getName(),"Gauss")==0)
+	if (strcmp(distrib->getName(), "Gauss") == 0)
 	{
 		const NormalDistribution* nDist = static_cast<const NormalDistribution*>(distrib);
 		ScalarType mu = 0;
@@ -334,7 +344,7 @@ double StatisticalTestingTools::testCloudWithStatisticalModel(const GenericDistr
 		customHistoMax = mu + static_cast<ScalarType>(3.0) * sqrt(sigma2);
 		histoMax = &customHistoMax;
 	}
-	else if (strcmp(distrib->getName(),"Weibull")==0)
+	else if (strcmp(distrib->getName(), "Weibull") == 0)
 	{
 		customHistoMin = 0;
 		histoMin = &customHistoMin;
@@ -344,7 +354,7 @@ double StatisticalTestingTools::testCloudWithStatisticalModel(const GenericDistr
 	void* additionalParameters[] = {	reinterpret_cast<void*>(const_cast<GenericDistribution*>(distrib)),
 										reinterpret_cast<void*>(&numberOfNeighbours),
 										reinterpret_cast<void*>(&numberOfChi2Classes),
-										reinterpret_cast<void*>(histoValues),
+										reinterpret_cast<void*>(histoValues.data()),
 										reinterpret_cast<void*>(histoMin),
 										reinterpret_cast<void*>(histoMax) };
 
@@ -367,9 +377,6 @@ double StatisticalTestingTools::testCloudWithStatisticalModel(const GenericDistr
 			maxChi2 = sqrt(maxChi2); //on travaille avec les racines carrees des distances du Chi2
 		}
 	}
-
-	delete[] histoValues;
-	histoValues = nullptr;
 
 	if (!inputOctree)
 		delete theOctree;


### PR DESCRIPTION
Scalar field is either reserved or resized depending on whether the cloud is already populated or not)