### PR TITLE
Octree multi-threading bug fix

### DIFF
--- a/include/DgmOctree.h
+++ b/include/DgmOctree.h
@@ -20,6 +20,9 @@
 //DGM: tests in progress
 //#define TEST_CELLS_FOR_SPHERICAL_NN
 
+//enables multi-threading handling
+#define ENABLE_MT_OCTREE
+
 namespace CCCoreLib
 {
 	class ReferenceCloud;
@@ -1250,6 +1253,25 @@ namespace CCCoreLib
 			\return the index of the cell (or 'm_numberOfProjectedPoints' if none found)
 		**/
 		unsigned getCellIndex(CellCode truncatedCellCode, unsigned char bitDec, unsigned begin, unsigned end) const;
+
+#ifdef ENABLE_MT_OCTREE
+		/*** FOR THE MULTI THREADING WRAPPER ***/
+		struct octreeCellDesc
+		{
+			DgmOctree::CellCode truncatedCode;
+			unsigned i1, i2;
+			unsigned char level;
+		};
+
+		DgmOctree* s_octree_MT = nullptr;
+		DgmOctree::octreeCellFunc s_func_MT = nullptr;
+		void** s_userParams_MT = nullptr;
+		GenericProgressCallback* s_progressCb_MT = nullptr;
+		NormalizedProgress* s_normProgressCb_MT = nullptr;
+		bool s_cellFunc_MT_success = true;
+
+		void LaunchOctreeCellFunc_MT(const octreeCellDesc& desc);
+#endif
 	};
 
 }

--- a/include/DgmOctree.h
+++ b/include/DgmOctree.h
@@ -1255,7 +1255,7 @@ namespace CCCoreLib
 		unsigned getCellIndex(CellCode truncatedCellCode, unsigned char bitDec, unsigned begin, unsigned end) const;
 
 #ifdef ENABLE_MT_OCTREE
-		/*** FOR THE MULTI THREADING WRAPPER ***/
+		//! Octree cell description helper struct
 		struct octreeCellDesc
 		{
 			DgmOctree::CellCode truncatedCode;
@@ -1263,14 +1263,19 @@ namespace CCCoreLib
 			unsigned char level;
 		};
 
-		DgmOctree* s_octree_MT = nullptr;
-		DgmOctree::octreeCellFunc s_func_MT = nullptr;
-		void** s_userParams_MT = nullptr;
-		GenericProgressCallback* s_progressCb_MT = nullptr;
-		NormalizedProgress* s_normProgressCb_MT = nullptr;
-		bool s_cellFunc_MT_success = true;
+		//! Structure containing objects needed to run octree operations in parallel
+		struct multiThreadingWrapper
+		{
+			DgmOctree *octree = nullptr;
+			DgmOctree::octreeCellFunc cell_func = nullptr;
+			void **userParams = nullptr;
+			GenericProgressCallback *progressCb = nullptr;
+			NormalizedProgress *normProgressCb = nullptr;
+			bool cellFunc_success = true;
 
-		void LaunchOctreeCellFunc_MT(const octreeCellDesc& desc);
+			void launchOctreeCellFunc(const octreeCellDesc& desc);
+		};
+		multiThreadingWrapper m_MT_wrapper;
 #endif
 	};
 

--- a/src/DgmOctree.cpp
+++ b/src/DgmOctree.cpp
@@ -21,8 +21,6 @@
 
 #ifdef CC_CORE_LIB_USES_QT_CONCURRENT
 #ifndef CC_DEBUG
-//enables multi-threading handling
-#define ENABLE_MT_OCTREE
 
 #include <QtConcurrentMap>
 #include <QtCore>
@@ -3246,23 +3244,7 @@ DgmOctree::octreeCell::~octreeCell()
 }
 
 #ifdef ENABLE_MT_OCTREE
-
-/*** FOR THE MULTI THREADING WRAPPER ***/
-struct octreeCellDesc
-{
-	DgmOctree::CellCode truncatedCode;
-	unsigned i1, i2;
-	unsigned char level;
-};
-
-static DgmOctree* s_octree_MT = nullptr;
-static DgmOctree::octreeCellFunc s_func_MT = nullptr;
-static void** s_userParams_MT = nullptr;
-static GenericProgressCallback* s_progressCb_MT = nullptr;
-static NormalizedProgress* s_normProgressCb_MT = nullptr;
-static bool s_cellFunc_MT_success = true;
-
-void LaunchOctreeCellFunc_MT(const octreeCellDesc& desc)
+void DgmOctree::LaunchOctreeCellFunc_MT(const octreeCellDesc& desc)
 {
 	//skip cell if process is aborted/has failed
 	if (!s_cellFunc_MT_success)
@@ -3529,7 +3511,7 @@ unsigned DgmOctree::executeFunctionForAllCellsAtLevel(	unsigned char level,
 			maxThreadCount = QThread::idealThreadCount();
 		}
 		QThreadPool::globalInstance()->setMaxThreadCount(maxThreadCount);
-		QtConcurrent::blockingMap(cells, LaunchOctreeCellFunc_MT);
+		QtConcurrent::blockingMap(cells, [this](const octreeCellDesc& desc) { LaunchOctreeCellFunc_MT(desc); } );
 
 #ifdef COMPUTE_NN_SEARCH_STATISTICS
 		FILE* fp = fopen("octree_log.txt", "at");
@@ -4079,7 +4061,7 @@ unsigned DgmOctree::executeFunctionForAllCellsStartingAtLevel(unsigned char star
 			maxThreadCount = QThread::idealThreadCount();
 		}
 		QThreadPool::globalInstance()->setMaxThreadCount(maxThreadCount);
-		QtConcurrent::blockingMap(cells, LaunchOctreeCellFunc_MT);
+		QtConcurrent::blockingMap(cells, [this](const octreeCellDesc& desc) { LaunchOctreeCellFunc_MT(desc); } );
 
 #ifdef COMPUTE_NN_SEARCH_STATISTICS
 		FILE* fp=fopen("octree_log.txt","at");


### PR DESCRIPTION
I have been attempting to use this library in a multi-threaded context and ran into issues with multiple threads reading/writing to various non-const static objects in the `DgmOctree` class that are used to facilitate it's own internal multi-threading. This PR moves those objects into the class to ensure that only one instance of the class in a single thread has access to them.

I believe there is a similar issue in `DistanceComputationTools` [here](https://github.com/CloudCompare/CCCoreLib/blob/61d69819765cd519a553994006ac9fb389ef1515/src/DistanceComputationTools.cpp#L1119), but it's not as simple to solve. Most of the methods that use objects are themselves static methods, meaning you couldn't move the objects into the `DistanceComputationTools` class and have those methods access them without making the functions non-static and breaking API