### PR TITLE
Fix shared scalar fields behavior

### DIFF
--- a/include/PointCloudTpl.h
+++ b/include/PointCloudTpl.h
@@ -397,6 +397,9 @@ namespace CCCoreLib
 				return -1;
 			}
 
+			// Link the scalar field to this cloud
+			sf->link();
+
 			return static_cast<int>(m_scalarFields.size()) - 1;
 		}
 

--- a/include/PointCloudTpl.h
+++ b/include/PointCloudTpl.h
@@ -37,10 +37,46 @@ namespace CCCoreLib
 			, m_currentOutScalarFieldIndex(-1)
 		{}
 
+		//! Copy Constructor
+		PointCloudTpl(const PointCloudTpl &rhs)
+			: T()
+			, m_points(rhs.m_points)
+			, m_bbox(rhs.m_bbox)
+			, m_currentPointIndex(rhs.m_currentPointIndex)
+			, m_scalarFields(rhs.m_scalarFields)
+			, m_currentInScalarFieldIndex(rhs.m_currentInScalarFieldIndex)
+			, m_currentOutScalarFieldIndex(rhs.m_currentOutScalarFieldIndex)
+		{
+			// Link all the existing scalar fields so they don't get deleted when rhs goes out of scope
+			for (ScalarField *sf : m_scalarFields)
+			{
+				sf->link();
+			}
+		}
+
 		//! Default destructor
 		virtual ~PointCloudTpl()
 		{
 			deleteAllScalarFields();
+		}
+
+		//! Copy Assignment
+		PointCloudTpl &operator=(const PointCloudTpl &rhs)
+		{
+			m_points = rhs.m_points;
+			m_bbox = rhs.m_bbox;
+			m_currentPointIndex = rhs.m_currentPointIndex;
+			m_scalarFields = rhs.m_scalarFields;
+			m_currentInScalarFieldIndex = rhs.m_currentInScalarFieldIndex;
+			m_currentOutScalarFieldIndex = rhs.m_currentOutScalarFieldIndex;
+
+			// Link all the existing scalar fields so they don't get deleted when rhs goes out of scope
+			for (ScalarField *sf : m_scalarFields)
+			{
+				sf->link();
+			}
+
+			return *this;
 		}
 
 		inline unsigned size() const override { return static_cast<unsigned>(m_points.size()); }


### PR DESCRIPTION
I have experienced a number of segfaults and undefined behavior when working with scalar fields added to point clouds. Here are two minimum working examples:

```c++
int main(int argc, char** argv)
{
  {
    // Create a cloud with some points and a scalar field
    CCCoreLib::PointCloud cloud_1;
    cloud_1.resize(100);
    sf_idx = cloud_1.addScalarField("test");

    // Copying the cloud copies the pointer to the scalar field allocated by cloud_1, but it doesn't increment the field's link count
    CCCoreLib::PointCloud cloud_2(cloud_1);
  }
  // When cloud_2 goes out of scope, the scalar field pointer is deleted
  // Now, when cloud_1 goes out of scope it will also attempt to delete the pointer, resulting in a fault
}
```

```c++
int main(int argc, char** argv)
{
  CCCoreLib::PointCloud cloud_2;
  int sf_idx;
  {
    // Create a cloud with some points and a scalar field
    CCCoreLib::PointCloud cloud_1;
    cloud_1.resize(100);
    sf_idx = cloud_1.addScalarField("test");

    // Similar to the copy constructor, setting cloud_3 equal to cloud_1 copies the pointer to the scalar field but doesn't increment the field's link count
    cloud_2 = cloud_1;
  }

  // The scalar field was deleted when cloud_1 went out of scope, so accessing it will result in undefined behavior
  const CCCoreLib::ScalarField* sf = cloud_2.getScalarField(sf_idx);
  ScalarType s = sf->operator[](0);
  std::cout << s << std::endl;
}
```

This PR adds a few changes to address these issues:
1. Increment the scalar field link count when adding scalar fields to a point cloud
1. Implement a copy constructor and copy assignment operator that increments the scalar field link count when copying