### PR TITLE
(Discussion) Initial refactor resampleCloudSpatially for multi-threading

### DIFF
--- a/include/CloudSamplingTools.h
+++ b/include/CloudSamplingTools.h
@@ -143,6 +143,24 @@ namespace CCCoreLib
 														DgmOctree* octree = nullptr,
 														GenericProgressCallback* progressCb = nullptr);
 
+		//! Resamples a point cloud (process based on inter point distance)
+		/** The cloud is resampled so that there is no point nearer than a given distance to other points
+			It works by picking a reference point, removing all points which are to close to this point, and repeating these two steps until the result is reached
+			\param cloud the point cloud to resample
+			\param minDistance the distance under which a point in the resulting cloud cannot have any neighbour
+			\param modParams parameters of the subsampling behavior modulation with a scalar field (optional)
+			\param octree associated octree if available
+			\param markers per-point marker for filtered-in points (required to be size of cloud)
+			\param progressCb the client application can get some notification of the process progress through this callback mechanism (see GenericProgressCallback)
+			\return a reference cloud corresponding to the resampling 'selection'
+		**/
+		static size_t resampleCloudSpatially(	GenericIndexedCloudPersist* cloud,
+												PointCoordinateType minDistance,
+												const SFModulationParams& modParams,
+												char* markers,
+												DgmOctree* octree = nullptr,
+												GenericProgressCallback* progressCb = nullptr);
+
 		//! Statistical Outliers Removal (SOR) filter
 		/** This filter removes points based on their mean distance to their distance (by comparing it to the average distance of all points to their neighbors).
 			It is equivalent to PCL StatisticalOutlierRemoval filter (see http://pointclouds.org/documentation/tutorials/statistical_outlier.php)


### PR DESCRIPTION
Note: This branch is untested.  It _does_ compile.

I have a heavily refactored version of `resampleCloudSpatially` that supports multi-threading.
In terms of licensing, ideally I could contribute that upstream rather than LGPL the surrounding code.
So the purpose of this PR is to open a discussion of what might be agreeable all around.

The reasoning for this change:
* Overload with a `marker`/`filtered count` back-end version of  `resampleCloudSpatially` that does _not_ allocate the markers or the output point cloud.
* In our use case we prefer the markers directly rather than converting from the ReferenceCloud
* In our use case the ReferenceCloud isn't needed, so don't build it
* Incrementally building the output cloud is problematic concurrently, better as a "gather" step once markers are finalised.
* Also, it resolves the problem of reserving the appropriate storage and then shrinking it again at the end.
* The pre-existing `resampleCloudSpatially` continues behaving in a compatible manner.

And to be clear this PR does not multi-thread but is more aligned with my more severe refactor.

Further thoughts:
* Perhaps move octree build up and out to the pre-existing overload, to share it read-only across worker threads.

To broadly describe the multi-threading approach, have concurrent neighbour searching, but lock access to the markers with a mutex and check if the current point is _still_ filtered-in before proceeding to filter-out the neighbourhood.  We do see some occasional non-determinism due to the non-deterministic order of points being processed, but the speedup is worthwhile.  With 12 threads we don't seem quite bottle-necked on updating markers, but that likely depends on the minimum distance and the typical neighbour count. 