### PR TITLE
Build in -fPIC mode, even for static library.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,8 @@ option( CCCORELIB_SCALAR_DOUBLE
 	OFF
 )
 
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
 # Add the library (shared or static)
 if ( CCCORELIB_SHARED )
 	add_library( CCCoreLib SHARED )


### PR DESCRIPTION
For some reason cmake does not default to position-independent code for static library targets.
We ran into issues linking shared libraries with static CCCoreLib unless using -fPIC on Linux.