### PR TITLE
re-encore 3 files from windows codepage 1252 to utf-8

### DIFF
--- a/include/GenericCloud.h
+++ b/include/GenericCloud.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-2.0-or-later
-// Copyright © EDF R&D / TELECOM ParisTech (ENST-TSI)
+// Copyright Â© EDF R&D / TELECOM ParisTech (ENST-TSI)
 
 #pragma once
 

--- a/src/ScalarFieldTools.cpp
+++ b/src/ScalarFieldTools.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-2.0-or-later
-// Copyright © EDF R&D / TELECOM ParisTech (ENST-TSI)
+// Copyright Â© EDF R&D / TELECOM ParisTech (ENST-TSI)
 
 #include <ScalarFieldTools.h>
 

--- a/src/StatisticalTestingTools.cpp
+++ b/src/StatisticalTestingTools.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-2.0-or-later
-// Copyright © EDF R&D / TELECOM ParisTech (ENST-TSI)
+// Copyright Â© EDF R&D / TELECOM ParisTech (ENST-TSI)
 
 #include <StatisticalTestingTools.h>
 


### PR DESCRIPTION
They caused problems when generaring Doxygen's xml.