### PR TITLE
Install CCMath.h file

### DIFF
--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -71,6 +71,7 @@ install(
 		CCConst.h
 		CCCoreLib.h
 		CCGeom.h
+		CCMath.h
 		CCMiscTools.h
 		CCPlatform.h
 		CCShareable.h


### PR DESCRIPTION
It was missing from the install list, so it gave an incomplete
installation

Fixes #72 