### PR TITLE
PointCloudTpl.h Fix Copyright sign

### DIFF
--- a/include/PointCloudTpl.h
+++ b/include/PointCloudTpl.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-2.0-or-later
-// Copyright © EDF R&D / TELECOM ParisTech (ENST-TSI)
+// Copyright Â© EDF R&D / TELECOM ParisTech (ENST-TSI)
 
 #pragma once
 


### PR DESCRIPTION
Fixes the Copyright sign © encoding.

Seems like I missed this in one my ealier attempts to fixes these.