### PR TITLE
Add __arm64__ as a CC_ENV_64

### DIFF
--- a/include/CCPlatform.h
+++ b/include/CCPlatform.h
@@ -19,7 +19,7 @@
 #else
 	#define CC_LINUX
 #endif
-#if defined(__x86_64__) || defined(__ppc64__)
+#if defined(__x86_64__) || defined(__ppc64__) || defined(__arm64__)
 	#define CC_ENV_64
 #else
 	#define CC_ENV_32


### PR DESCRIPTION
So that macOs builds of CloudCompare on Apple Silicon macs
properly shows 64 bits in its About Dialog & main window.