### PR TITLE
Fix tbb:2021 build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,11 +167,17 @@ if ( CCCORELIB_USE_TBB )
 	find_package( TBB COMPONENTS tbb CONFIG )
 
 	if ( TBB_FOUND )
-		target_link_libraries( CCCoreLib
-			PUBLIC
+		if ( ${TBB_VERSION} VERSION_GREATER 2021.0.0 )
+			target_link_libraries( CCCoreLib
+				PUBLIC
+				TBB::tbb
+			)
+		else()
+			target_link_libraries( CCCoreLib
+				PUBLIC
 				${TBB_IMPORTED_TARGETS}
-		)
-
+			)
+		endif()
 		target_compile_definitions( CCCoreLib
 			PUBLIC
 				CC_CORE_LIB_USES_TBB

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -181,6 +181,7 @@ if ( CCCORELIB_USE_TBB )
 		target_compile_definitions( CCCoreLib
 			PUBLIC
 				CC_CORE_LIB_USES_TBB
+				TBB_VERSION="${TBB_VERSION}"
 		)
 	endif()
 endif()


### PR DESCRIPTION
* Move `tbb` version scheme from header to the cmake define.
* Explicate define targets as `tbb_imported_targets` was deprecated.