### PR TITLE
fix the CloudCompare bug #1889 Registration tool broken, on macOS

### DIFF
--- a/src/DgmOctree.cpp
+++ b/src/DgmOctree.cpp
@@ -3232,7 +3232,9 @@ unsigned DgmOctree::executeFunctionForAllCellsAtLevel(	unsigned char level,
 			progressCb->update(0);
 			m_MT_wrapper->normProgressCb = new NormalizedProgress(progressCb, m_theAssociatedCloud->size());
 			progressCb->start();
+#ifndef __APPLE__
 			QCoreApplication::processEvents(QEventLoop::EventLoopExec); // to allow the GUI to refresh itself
+#endif
 		}
 
 #ifdef COMPUTE_NN_SEARCH_STATISTICS
@@ -3427,7 +3429,9 @@ unsigned DgmOctree::executeFunctionForAllCellsStartingAtLevel(unsigned char star
 			if (progressCb)
 			{
 				progressCb->update((100.0f * cell.index) / m_numberOfProjectedPoints);
+#ifndef __APPLE__
 				QCoreApplication::processEvents(QEventLoop::EventLoopExec); // to allow the GUI to refresh itself
+#endif
 				if (progressCb->isCancelRequested())
 				{
 					result = false;


### PR DESCRIPTION
I am not sure to understand why these processEvents calls freezes the ICP  on macOS...
Another possible fix is to set processCb=nullptr in ICPRegistrationTools::Register (thats why Registration worked when called from Python, with a null processCb).