### PR TITLE
Add __aarch64__ as a CC_ENV_64

### DIFF
--- a/include/CCPlatform.h
+++ b/include/CCPlatform.h
@@ -19,7 +19,7 @@
 #else
 	#define CC_LINUX
 #endif
-#if defined(__x86_64__) || defined(__ppc64__) || defined(__arm64__)
+#if defined(__x86_64__) || defined(__ppc64__) || defined(__arm64__) || defined(__aarch64__)
 	#define CC_ENV_64
 #else
 	#define CC_ENV_32


### PR DESCRIPTION
Required for ARM 64 bit builds to show up as 64 bit under Linux, as that uses `__aarch64__` instead of `__arm64__`.

Same spirit as 9f25a143791fef27d5b2989383fae26aa4c1513f.