### PR TITLE
CGAL::No_intersection_tag is deprecated since CGAL 5.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,7 +195,7 @@ endif()
 
 # CGAL (optional)
 if ( CCCORELIB_USE_CGAL )
-	find_package( CGAL REQUIRED )
+	find_package( CGAL 5.1 REQUIRED )
 
 	if( WIN32 )
 		# Need to force the visibility of these variables so that we can use them later

--- a/src/Delaunay2dMesh.cpp
+++ b/src/Delaunay2dMesh.cpp
@@ -69,7 +69,9 @@ bool Delaunay2dMesh::buildMesh(	const std::vector<CCVector2>& points2D,
 	//We define a vertex_base with info. The "info" (std::size_t) allow us to keep track of the original point index.
 	using Vb = CGAL::Triangulation_vertex_base_with_info_2<std::size_t, K>;
 	using Fb = CGAL::Constrained_triangulation_face_base_2<K>;
-	using Itag = CGAL::No_intersection_tag; //This tag could ben changed if we decide to handle intersection
+	// This tag could be changed if we decide to handle more complex intersections
+	// for now it allows to handle basic ones without adding steiner points
+	using Itag = CGAL::No_constraint_intersection_requiring_constructions_tag;
 	using Tds = CGAL::Triangulation_data_structure_2<Vb, Fb>;
 	using CDT = CGAL::Constrained_Delaunay_triangulation_2<K, Tds, Itag>;
 	using cgalPoint = CDT::Point;


### PR DESCRIPTION
 CGAL::No_constraint_intersection_requiring_constructions_tag
is the strict equivalent. See https://www.cgal.org/2020/09/08/cgal51/

We now require at least CGAL 5.1 (from 2020)