### PR TITLE
Missing assert header in RayAndBox.h 

### DIFF
--- a/include/Kriging.h
+++ b/include/Kriging.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-2.0-or-later
-// Copyright © EDF R&D / TELECOM ParisTech (ENST-TSI)
+// Copyright Â© EDF R&D / TELECOM ParisTech (ENST-TSI)
 
 #pragma once
 

--- a/include/RayAndBox.h
+++ b/include/RayAndBox.h
@@ -3,7 +3,11 @@
 
 #pragma once
 
+//Local
 #include "CCGeom.h"
+
+//System
+#include <cassert>
 
 namespace CCCoreLib
 {
@@ -20,31 +24,31 @@ namespace CCCoreLib
 			invDir = Vector3Tpl<T>(1/rayAxis.x, 1/rayAxis.y, 1/rayAxis.z); // +/-infinity is acceptable here because we are mainly interested in the sign
 			sign = Tuple3i(invDir.x < 0, invDir.y < 0, invDir.z < 0);
 		}
-		
+
 		double radialSquareDistance(const Vector3Tpl<T>& P) const
 		{
 			Vector3Tpl<T> OP = P - origin;
 			return OP.cross(dir).norm2d();
 		}
-		
+
 		double squareDistanceToOrigin(const Vector3Tpl<T>& P) const
 		{
 			Vector3Tpl<T> OP = P - origin;
 			return OP.norm2d();
 		}
-		
+
 		void squareDistances(const Vector3Tpl<T>& P, double& radial, double& toOrigin) const
 		{
 			Vector3Tpl<T> OP = P - origin;
 			radial = OP.cross(dir).norm2d();
 			toOrigin = OP.norm2d();
 		}
-		
+
 		Vector3Tpl<T> dir, origin;
 		Vector3Tpl<T> invDir;
 		Tuple3i sign;
 	};
-		
+
 	//! Simple axis aligned box structure
 	template <typename T > struct AABB
 	{
@@ -53,11 +57,11 @@ namespace CCCoreLib
 			assert(minCorner.x <= maxCorner.x);
 			assert(minCorner.y <= maxCorner.y);
 			assert(minCorner.z <= maxCorner.z);
-			
+
 			corners[0] = minCorner;
 			corners[1] = maxCorner;
 		}
-		
+
 		/*
 		 * Ray-box intersection using IEEE numerical properties to ensure that the
 		 * test is both robust and efficient, as described in:
@@ -72,32 +76,32 @@ namespace CCCoreLib
 			T tmax  = (corners[1-r.sign.x].x - r.origin.x) * r.invDir.x;
 			T tymin = (corners[  r.sign.y].y - r.origin.y) * r.invDir.y;
 			T tymax = (corners[1-r.sign.y].y - r.origin.y) * r.invDir.y;
-			
+
 			if (tmin > tymax || tymin > tmax)
 				return false;
 			if (tymin > tmin)
 				tmin = tymin;
 			if (tymax < tmax)
 				tmax = tymax;
-			
+
 			T tzmin = (corners[  r.sign.z].z - r.origin.z) * r.invDir.z;
 			T tzmax = (corners[1-r.sign.z].z - r.origin.z) * r.invDir.z;
-			
+
 			if (tmin > tzmax || tzmin > tmax)
 				return false;
 			if (tzmin > tmin)
 				tmin = tzmin;
 			if (tzmax < tmax)
 				tmax = tzmax;
-			
+
 			if (t0)
 				*t0 = tmin;
 			if (t1)
 				*t1 = tmax;
-			
+
 			return true;
 		}
-		
+
 		Vector3Tpl<T> corners[2];
 	};
 }

--- a/include/ScalarFieldTools.h
+++ b/include/ScalarFieldTools.h
@@ -7,7 +7,6 @@
 #include "CCToolbox.h"
 #include "DgmOctree.h"
 
-
 namespace CCCoreLib
 {
 	class GenericCloud;

--- a/src/AutoSegmentationTools.cpp
+++ b/src/AutoSegmentationTools.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-2.0-or-later
-// Copyright © EDF R&D / TELECOM ParisTech (ENST-TSI)
+// Copyright Â© EDF R&D / TELECOM ParisTech (ENST-TSI)
 
 #include <AutoSegmentationTools.h>
 

--- a/src/CCMiscTools.cpp
+++ b/src/CCMiscTools.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-2.0-or-later
-// Copyright © EDF R&D / TELECOM ParisTech (ENST-TSI)
+// Copyright Â© EDF R&D / TELECOM ParisTech (ENST-TSI)
 
 #include "CCMiscTools.h"
 

--- a/src/ChamferDistanceTransform.cpp
+++ b/src/ChamferDistanceTransform.cpp
@@ -6,7 +6,6 @@
 //system
 #include <algorithm>
 #include <cassert>
-#include <cstring>
 
 using namespace CCCoreLib;
 

--- a/src/GridAndMeshIntersection.cpp
+++ b/src/GridAndMeshIntersection.cpp
@@ -298,4 +298,3 @@ bool GridAndMeshIntersection::hasGridMeshIntersection() const
 {
 	return m_perCellTriangleList.isInitialized();
 }
-

--- a/src/Kriging.cpp
+++ b/src/Kriging.cpp
@@ -1,11 +1,10 @@
 // SPDX-License-Identifier: LGPL-2.0-or-later
-// Copyright © EDF R&D / TELECOM ParisTech (ENST-TSI)
+// Copyright Â© EDF R&D / TELECOM ParisTech (ENST-TSI)
 
 #include "../include/Kriging.h"
 
 //System
 #include <algorithm>
-#include <array>
 #include <assert.h>
 #include <map>
 #include <random>
@@ -93,7 +92,7 @@ public:
 		}
 
 		// Now solve upper triangular (transpose of lower triangular) * x = y with back substitution.
-		// Note that x can be solved in place using the existing y vector.  No need to allocate 
+		// Note that x can be solved in place using the existing y vector.  No need to allocate
 		// another vector.
 		for (int i = static_cast<int>(b.size()) - 1; i >= 0; i--)
 		{
@@ -193,7 +192,7 @@ public:
 		// The rows of this matrix have been permutated during the decomposition process.  The
 		// m_rowPermutation indicates the proper row order.
 
-		// The lower diagonal matrix only includes elements below the diagonal with diagonal 
+		// The lower diagonal matrix only includes elements below the diagonal with diagonal
 		// elements set to 1.
 
 		// The upper diagonal matrix is fully specified.
@@ -599,7 +598,7 @@ Kriging::KrigeParams Kriging::computeDefaultParameters() const
 {
 	// Note: Determination of sill and range are only rough estimates.
 	//       It is up to the user to interpret the empirical and model
-	//       variogram plots to assess the validity of the parameters 
+	//       variogram plots to assess the validity of the parameters
 	//       used in the chosen model.
 
 	// For fixed models, range is the first distance where the sill is reached.
@@ -684,7 +683,7 @@ Kriging::KrigeParams Kriging::computeDefaultParameters() const
 				assert(shift >= 1 && shift < static_cast<int>(MaxPointCount));
 				int j = (i + shift) % static_cast<int>(MaxPointCount);
 				assert(i != j);
-				
+
 				double delta = m_dataPoints[i].value - m_dataPoints[j].value;
 				double variance = (delta * delta) / 2;
 
@@ -793,7 +792,7 @@ Kriging::KrigeParams Kriging::computeDefaultParameters() const
 		for (size_t i = 0; i < lagSemivariance.size(); ++i)
 		{
 			double semivariance = lagSemivariance[i];
-			
+
 			if (semivariance > estimatedParams.sill)
 			{
 				estimatedParams.range = (i != 0 ? (lagDistance[i - 1] + lagDistance[i]) / 2.0 : lagDistance[i]);

--- a/src/LocalModel.cpp
+++ b/src/LocalModel.cpp
@@ -5,7 +5,6 @@
 
 //local
 #include "DistanceComputationTools.h"
-#include "GenericIndexedMesh.h"
 #include "GenericMesh.h"
 #include "GenericTriangle.h"
 
@@ -186,7 +185,7 @@ LocalModel* LocalModel::New(LOCAL_MODEL_TYPES type,
 		case TRI:
 		{
 			std::string	errorStr;
-			
+
 			GenericMesh* tri = subset.triangulateOnPlane( Neighbourhood::DUPLICATE_VERTICES,
 														  Neighbourhood::IGNORE_MAX_EDGE_LENGTH,
 														  errorStr ); //'subset' is potentially associated to a volatile ReferenceCloud, so we must duplicate vertices!

--- a/src/ReferenceCloud.cpp
+++ b/src/ReferenceCloud.cpp
@@ -3,9 +3,6 @@
 
 #include "ReferenceCloud.h"
 
-//system
-#include <algorithm>
-
 using namespace CCCoreLib;
 
 ReferenceCloud::ReferenceCloud(GenericIndexedCloudPersist* associatedCloud)

--- a/src/ScalarField.cpp
+++ b/src/ScalarField.cpp
@@ -4,7 +4,6 @@
 #include <ScalarField.h>
 
 //System
-#include <cassert>
 #include <cstring>
 
 using namespace CCCoreLib;


### PR DESCRIPTION
RayAnBox.h is missing the cassert header, but this issue is often overlooked because it is included after another header that already includes it.
This PR also fix non utf-8 chars in some files and remove unneeded header inclusions.